### PR TITLE
Add setup instructions for Nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install vue primevue tailwindcss
 npm install @digitalservicebund/ris-ui
 ```
 
-## Usage
+### Vue setup
 
 Import and apply the RIS UI theme, styling, and fonts where you set up your application (typically `main.ts`):
 
@@ -36,6 +36,28 @@ Import and apply the RIS UI theme, styling, and fonts where you set up your appl
 +   pt: RisUiTheme,
   })
 ```
+
+### Nuxt setup
+
+If using Nuxt, skip the Vue setup above.
+
+Add the PrimeVue plugin and set the RIS UI theme, styling, and fonts to your `nuxt.config.ts`:
+
+```diff
+  import { RisUiTheme } from "@digitalservicebund/ris-ui/primevue";
+  export default defineNuxtConfig({
+    modules: [
++     "@primevue/nuxt-module",
+    ],
++   primevue: {
++     pt: RisUiTheme,
++     unstyled: true,
++   },
+  // your other configuration
+  })
+```
+
+## Tailwind usage
 
 If you want, also install the Tailwind preset (for colors, spacings, etc.) and plugin (for typography classes, etc.):
 

--- a/README.md
+++ b/README.md
@@ -41,20 +41,45 @@ Import and apply the RIS UI theme, styling, and fonts where you set up your appl
 
 If using Nuxt, skip the Vue setup above.
 
-Add the PrimeVue plugin and set the RIS UI theme, styling, and fonts to your `nuxt.config.ts`:
+Install the Nuxt PrimeVue module:
+
+```sh
+npm install @primevue/nuxt-module
+```
+
+Add the PrimeVue module, configure it, and load the CSS in `nuxt.config.ts`:
 
 ```diff
-  import { RisUiTheme } from "@digitalservicebund/ris-ui/primevue";
+  // nuxt.config.ts
   export default defineNuxtConfig({
+    // your other configuration
     modules: [
 +     "@primevue/nuxt-module",
     ],
 +   primevue: {
-+     pt: RisUiTheme,
-+     unstyled: true,
++      usePrimeVue: false, // configured in plugins/ris-ui.ts
 +   },
-  // your other configuration
+    css: [
+      // any other CSS
++     "@digitalservicebund/ris-ui/primevue/style.css",
++     "@digitalservicebund/ris-ui/fonts.css",
+    ],
   })
+```
+
+Add a new Nuxt plugin to configure PrimeVue:
+
+```typescript
+// plugins/ris-ui.ts
+import { RisUiTheme } from "@digitalservicebund/ris-ui/primevue";
+import PrimeVue from "primevue/config";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(PrimeVue, {
+    pt: RisUiTheme,
+    unstyled: true,
+  });
+});
 ```
 
 ## Tailwind usage
@@ -71,6 +96,25 @@ If you want, also install the Tailwind preset (for colors, spacings, etc.) and p
 
     // your other configuration
   };
+```
+
+To avoid issues with conflicting `@layer` directives, make sure to integrate the `postcss-import` module in your PostCSS configuration:
+
+See https://tailwindcss.com/docs/adding-custom-styles#using-multiple-css-files
+
+### Using Nuxt
+
+You may add the `postcss-import` module to your `nuxt.config.ts` file:
+
+```diff
+  // nuxt.config.ts
+  postcss: {
+    plugins: {
++     "postcss-import": {},
+      tailwindcss: {},
+      autoprefixer: {},
+    },
+  },
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Install the Nuxt PrimeVue module:
 npm install @primevue/nuxt-module
 ```
 
-Add the PrimeVue module, configure it, and load the CSS in `nuxt.config.ts`:
+Add the PrimeVue module and configure it in `nuxt.config.ts`:
 
 ```diff
   // nuxt.config.ts
@@ -59,11 +59,6 @@ Add the PrimeVue module, configure it, and load the CSS in `nuxt.config.ts`:
 +   primevue: {
 +      usePrimeVue: false, // configured in plugins/ris-ui.ts
 +   },
-    css: [
-      // any other CSS
-+     "@digitalservicebund/ris-ui/primevue/style.css",
-+     "@digitalservicebund/ris-ui/fonts.css",
-    ],
   })
 ```
 
@@ -81,6 +76,17 @@ export default defineNuxtPlugin((nuxtApp) => {
   });
 });
 ```
+
+Finally, add the styles (e.g. `assets/main.css`):
+
+```css
+@import "@digitalservicebund/ris-ui/primevue/style.css";
+@import "@digitalservicebund/ris-ui/fonts.css";
+
+/* Your other CSS */
+```
+
+If not using Tailwind, you may also add these styles directly to the `css` section of `nuxt.config.ts`.
 
 ## Tailwind usage
 


### PR DESCRIPTION
Added setup instructions for Nuxt, including
- Defining a custom Nuxt plugin to configure PrimeVue, because the [configuration options](https://primevue.org/nuxt/#options) in `nuxt.config.ts` did not seem to have any effect
- Installing the PrimeVue Nuxt plugin
- Resolving Tailwind layer conflicts by integrating the `postcss-import` module: Importing the RIS-UI style broke the Tailwind behavior unless the `@tailwind base` directive was removed, adding `postcss-import` fixed it