### PR TITLE
feat(button): handle custom slot-based icons

### DIFF
--- a/src/primevue/button/button.stories.ts
+++ b/src/primevue/button/button.stories.ts
@@ -106,11 +106,13 @@ export const WithIcon: Story = {
     setup() {
       return { args };
     },
-    template: html` <PrimevueButton v-bind="args">
-      <template #icon>
-        <IconCheck />
-      </template>
-    </PrimevueButton>`,
+    template: html`
+      <PrimevueButton v-bind="args">
+        <template #icon="slotProps">
+          <IconCheck :class="slotProps.class" />
+        </template>
+      </PrimevueButton>
+    `,
   }),
 };
 

--- a/src/primevue/button/button.ts
+++ b/src/primevue/button/button.ts
@@ -56,7 +56,12 @@ const button: ButtonPassThroughOptions = {
   label: ({ props }) => ({
     class: {
       hidden: !props.label,
-      [tw`-order-1`]: props.iconPos === "right",
+    },
+  }),
+
+  icon: ({ props }) => ({
+    class: {
+      "order-last": props.iconPos == "right",
     },
   }),
 

--- a/src/primevue/checkbox/checkbox.stories.ts
+++ b/src/primevue/checkbox/checkbox.stories.ts
@@ -13,6 +13,11 @@ const meta: Meta<typeof Checkbox> = {
     disabled: false,
     invalid: false,
     indeterminate: false,
+    size: undefined,
+  },
+
+  argTypes: {
+    size: { control: "select", options: [undefined, "large"] },
   },
 };
 
@@ -27,6 +32,22 @@ export const Default: Story = {
       return { args, checked };
     },
     template: html`<Checkbox binary v-bind="args" v-model="checked" />`,
+  }),
+};
+
+export const Large: Story = {
+  render: (args) => ({
+    components: { Checkbox },
+    setup() {
+      const checked = ref(true);
+      return { args, checked };
+    },
+    template: html`<Checkbox
+      binary
+      v-bind="args"
+      size="large"
+      v-model="checked"
+    />`,
   }),
 };
 

--- a/src/primevue/checkbox/checkbox.ts
+++ b/src/primevue/checkbox/checkbox.ts
@@ -2,8 +2,16 @@ import { tw } from "@/lib/tags";
 import { CheckboxPassThroughOptions } from "primevue/checkbox";
 
 const checkbox: CheckboxPassThroughOptions = {
-  root: {
-    class: tw`[&+label]:ris-label1-regular relative inline-block h-24 min-h-24 w-24 min-w-24 [&+label]:ml-8`,
+  root: ({ props }) => {
+    // Base
+    const base = tw`[&+label]:ris-label1-regular relative inline-block h-24 min-h-24 w-24 min-w-24 [&+label]:ml-8`;
+
+    return {
+      class: {
+        [base]: true,
+        [tw`h-32 min-h-32 w-32 min-w-32`]: props.size === "large",
+      },
+    };
   },
 
   input: {


### PR DESCRIPTION
PrimeVue’s <Button> component only automatically positions built-in string-based icons (e.g., icon='pi pi-check'). It does not handle positioning for custom slot-based icons, since it assumes it is controlled manually - which is why we need to manually apply an order style to our custom icon component and pass it through the slot.