### PR TITLE
fix(button): un-hide button outlines

### DIFF
--- a/src/primevue/breadcrumb/breadcrumb.ts
+++ b/src/primevue/breadcrumb/breadcrumb.ts
@@ -9,7 +9,7 @@ const breadcrumb: BreadcrumbPassThroughOptions = {
     class: tw`flex-no-wrap ris-label1-regular my-2 flex items-center break-all`,
   },
   itemLink: {
-    class: tw`inline-flex cursor-pointer items-center text-blue-800 outline-hidden hover:underline focus:outline focus:outline-4 focus:outline-offset-4 focus:outline-blue-800`,
+    class: tw`inline-flex cursor-pointer items-center text-blue-800 hover:underline focus:outline focus:outline-4 focus:outline-offset-4 focus:outline-blue-800`,
   },
   separator: {
     class: tw`mx-6 flex items-center text-gray-600`,

--- a/src/primevue/button/button.ts
+++ b/src/primevue/button/button.ts
@@ -4,7 +4,7 @@ import { tw } from "@/lib/tags.ts";
 const button: ButtonPassThroughOptions = {
   root: ({ props, instance }) => {
     // Base
-    const base = tw`relative inline-flex max-w-full cursor-pointer items-center justify-center gap-8 rounded-none text-center outline-hidden focus:outline-4 focus:outline-offset-4 focus:outline-blue-800 active:outline-hidden disabled:cursor-not-allowed disabled:outline-hidden`;
+    const base = tw`relative inline-flex max-w-full cursor-pointer items-center justify-center gap-8 rounded-none text-center focus:outline-4 focus:outline-offset-4 focus:outline-blue-800 active:outline-hidden disabled:cursor-not-allowed disabled:outline-hidden`;
 
     // Severity
     const severity = props.severity ?? "primary";


### PR DESCRIPTION
In the RIS Portal, having the `outline-hidden` class on the button sets `--tw-outline-style: none`, causing usage of e.g. `focus:outline-4` to use `outline-style: var(--tw-outline-style);` and keeping the outline invisible.

Right now, it's unclear to me why this isn't an issue with Storybook and other applications.

Regardless, the [docs](https://tailwindcss.com/docs/outline-style#hiding-an-outline) state
> Use the outline-hidden utility to hide the default browser outline on focused elements, [...]

Given that there is no default browser outline to be replaced by other styles, removing this base style seems reasonable.