### PR TITLE
fix(RisExpandableText): add tolerance prop to allow for slight overflow

### DIFF
--- a/src/components/RisExpandableText/RisExpandableText.stories.ts
+++ b/src/components/RisExpandableText/RisExpandableText.stories.ts
@@ -9,6 +9,7 @@ const meta: Meta<typeof RisExpandableText> = {
 
   args: {
     length: 3,
+    tolerance: 3,
   },
 };
 
@@ -29,6 +30,24 @@ export const Default: StoryObj<typeof meta> = {
         velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
         occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.
+      </RisExpandableText>
+    </div>`,
+  }),
+};
+
+export const WithMixedContent: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { RisExpandableText },
+    setup() {
+      return { args };
+    },
+    template: html`<div class="max-w-320">
+      <RisExpandableText v-bind="args">
+        <div>
+          <h1 class="text-4xl">
+            This heading should neatly fit into three lines <sup>*</sup>
+          </h1>
+        </div>
       </RisExpandableText>
     </div>`,
   }),

--- a/src/components/RisExpandableText/RisExpandableText.vue
+++ b/src/components/RisExpandableText/RisExpandableText.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import { ref, useTemplateRef, watchEffect, useId } from "vue";
 
-const { length = 3 } = defineProps<{
+const { length = 3, tolerance = 3 } = defineProps<{
   /**
    * Specifies the maximum number of visible lines.
    * @default 3
    */
   length?: number;
+  /**
+   * Specifies a pixels threshold under which overflowing content would be
+   * ignored.
+   * @default 3
+   */
+  tolerance?: number;
 }>();
 
 const expanded = defineModel<boolean>("expanded", { default: false });
@@ -20,7 +26,8 @@ const textId = useId();
 watchEffect(() => {
   if (textContent.value instanceof HTMLDivElement) {
     canExpand.value =
-      textContent.value.scrollHeight > textContent.value.clientHeight;
+      textContent.value.scrollHeight - tolerance >
+      textContent.value.clientHeight;
   }
 });
 </script>


### PR DESCRIPTION
In Firefox, some content would fit into the RisExpandableText area, but still display the "Mehr anzeigen" button, which does nothing in this case.

To reproduce, open the `WithMixedContent` story in Firefox, e.g. 137.0b10.
The scrollHeight should come out to 115px, the clientHeight to just 113px.

As a workaround, a tolerance value is added.