### PR TITLE
fix(select): support appendTo=self

### DIFF
--- a/src/primevue/select/select.stories.ts
+++ b/src/primevue/select/select.stories.ts
@@ -14,6 +14,16 @@ const meta: Meta<typeof PrimevueSelect> = {
     placeholder: "Dropdown",
     disabled: false,
     invalid: false,
+    appendTo: "body",
+  },
+  argTypes: {
+    appendTo: {
+      options: ["self", "body"],
+      control: {
+        type: "select",
+        labels: ["self", "body"],
+      },
+    },
   },
 };
 

--- a/src/primevue/select/select.ts
+++ b/src/primevue/select/select.ts
@@ -4,7 +4,7 @@ import { SelectPassThroughOptions } from "primevue/select";
 const select: SelectPassThroughOptions = {
   root: ({ props, state }) => {
     // Base
-    const base = tw`ris-body2-regular [&+small]:ris-label3-regular inline-flex h-48 items-center justify-between border-2 bg-white py-4 pr-12 pl-16 [&+small]:mt-2 [&+small]:flex [&+small]:items-center [&+small]:gap-4 [&+small]:text-gray-900 [&[aria-invalid="true"]+small]:text-red-900`;
+    const base = tw`ris-body2-regular [&+small]:ris-label3-regular relative inline-flex h-48 items-center justify-between border-2 bg-white py-4 pr-12 pl-16 [&+small]:mt-2 [&+small]:flex [&+small]:items-center [&+small]:gap-4 [&+small]:text-gray-900 [&[aria-invalid="true"]+small]:text-red-900`;
 
     // States
     const normal = tw`cursor-pointer border-blue-800`;


### PR DESCRIPTION
In cases where the select might be inside a static element (e.g., a sidebar),
 attaching the dropdown element to the body might cause it to scroll away from the parent.

To prevent that, appendTo can be set to self, or another element. However, this requires `relative` on the container.