### PR TITLE
fix(autocomplete): remove min-width

### DIFF
--- a/src/primevue/autocomplete/autocomplete.ts
+++ b/src/primevue/autocomplete/autocomplete.ts
@@ -35,7 +35,7 @@ const autocomplete: AutoCompletePassThroughOptions = {
     class: tw`hover:bg-blue-100 data-[p-focus=true]:bg-blue-200`,
   },
   overlay: {
-    class: tw`min-w-288 overflow-auto bg-white px-8 py-12 shadow-md`,
+    class: tw`overflow-auto bg-white px-8 py-12 shadow-md`,
   },
 };
 


### PR DESCRIPTION
Setting a minimum width on the overlay causes it to disappear
on hover when attached to "self"
and narrower than the specified width, see https://digitalservicebund.atlassian.net/browse/RISDEV-7571