### PR TITLE
feat(tabs): add support for design tokens

### DIFF
--- a/src/primevue/tabs/tabs.stories.style.css
+++ b/src/primevue/tabs/tabs.stories.style.css
@@ -1,0 +1,6 @@
+.custom-tabs {
+  --p-tabs-tablist-border-color: var(--color-blue-800);
+  --p-tabs-tab-border-color: transparent;
+  --p-tabs-tab-active-background: var(--color-blue-300);
+  --p-tabs-tabpanel-background: var(--color-blue-300);
+}

--- a/src/primevue/tabs/tabs.stories.ts
+++ b/src/primevue/tabs/tabs.stories.ts
@@ -6,6 +6,8 @@ import Tab from "primevue/tab";
 import TabPanels from "primevue/tabpanels";
 import TabPanel from "primevue/tabpanel";
 
+import "./tabs.stories.style.css";
+
 const meta: Meta<typeof Tabs> = {
   // @ts-expect-error Component type broken
   component: Tabs,
@@ -23,44 +25,94 @@ export const Default: StoryObj<typeof meta> = {
     setup() {
       return { args };
     },
-    template: html`<PrimeVueTabs v-bind="args" />
-      <Tabs value="0">
+    template: html` <Tabs value="0" class="team-a-tabs">
+      <TabList>
+        <Tab value="0">Lorem ipsum</Tab>
+        <Tab value="1">Duis aute</Tab>
+        <Tab value="2">Nam liber</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel value="0">
+          <p class="m-0">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur.
+          </p>
+        </TabPanel>
+        <TabPanel value="1">
+          <p class="m-0">
+            Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum Et harumd und lookum like Greek to me, dereud
+            facilis est er expedit distinct.
+          </p>
+        </TabPanel>
+        <TabPanel value="2">
+          <p class="m-0">
+            Nam liber te conscient to factor tum poen legum odioque civiuda. Et
+            tam neque pecun modut est neque nonor et imper ned libidig met,
+            consectetur adipiscing elit, sed ut labore et dolore magna aliquam
+            makes one wonder who would ever read this stuff? Bis nostrud
+            exercitation ullam mmodo consequet. Duis aute in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur.
+          </p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>`,
+  }),
+};
+
+Default.parameters = {
+  docs: {
+    source: {
+      type: "code",
+    },
+  },
+};
+
+export const CustomStyle: StoryObj<typeof meta> = {
+  render: (args) => ({
+    components: { Tabs, TabList, Tab, TabPanels, TabPanel },
+    setup() {
+      return { args };
+    },
+    template: html`
+      <Tabs value="0" class="custom-tabs">
         <TabList>
-          <Tab value="0">Lorem ipsum</Tab>
+          <Tab value="0">Custom stlye</Tab>
           <Tab value="1">Duis aute</Tab>
           <Tab value="2">Nam liber</Tab>
         </TabList>
         <TabPanels>
           <TabPanel value="0">
             <p class="m-0">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-              reprehenderit in voluptate velit esse cillum dolore eu fugiat
-              nulla pariatur.
+              Use supported PrimeVue design tokens to customize the appearance.
+              See <pre class="inline">tabs.stores.style.css</pre> for sample usage.
             </p>
           </TabPanel>
           <TabPanel value="1">
             <p class="m-0">
-              Duis aute irure dolor in reprehenderit in voluptate velit esse
-              cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-              cupidatat non proident, sunt in culpa qui officia deserunt mollit
-              anim id est laborum Et harumd und lookum like Greek to me, dereud
-              facilis est er expedit distinct.
+              Content
             </p>
           </TabPanel>
           <TabPanel value="2">
             <p class="m-0">
-              Nam liber te conscient to factor tum poen legum odioque civiuda.
-              Et tam neque pecun modut est neque nonor et imper ned libidig met,
-              consectetur adipiscing elit, sed ut labore et dolore magna aliquam
-              makes one wonder who would ever read this stuff? Bis nostrud
-              exercitation ullam mmodo consequet. Duis aute in voluptate velit
-              esse cillum dolore eu fugiat nulla pariatur.
+              Content
             </p>
           </TabPanel>
         </TabPanels>
       </Tabs>`,
   }),
+};
+
+CustomStyle.parameters = {
+  docs: {
+    source: {
+      type: "code",
+    },
+  },
 };

--- a/src/primevue/tabs/tabs.ts
+++ b/src/primevue/tabs/tabs.ts
@@ -4,9 +4,10 @@ import type { TabPanelPassThroughOptions } from "primevue/tabpanel";
 import type { TabListPassThroughOptions } from "primevue/tablist";
 
 export const tab: TabPassThroughOptions = {
-  root: ({ context }) => {
+  root: ({ context, ...other }) => {
+    console.log(context, other);
     const base = tw`ris-body2-bold h-64 border-b-4 border-b-transparent py-4 pr-24 pl-20 outline-0 -outline-offset-4 outline-blue-800 focus-visible:outline-4`;
-    const active = tw`z-10 border-gray-600 bg-white text-black shadow-[-1px_-1px_0_0_var(--color-gray-600),1px_-1px_0_0_var(--color-gray-600)]`;
+    const active = tw`z-10 bg-[var(--p-tabs-tab-active-background,white)] text-black shadow-[-1px_-1px_0_0_var(--p-tabs-tab-border-color,var(--color-gray-600)),1px_-1px_0_0_var(--p-tabs-tab-border-color,var(--color-gray-600))]`;
     const inactive = tw`cursor-pointer text-blue-800 hover:border-b-blue-800`;
     return {
       class: {
@@ -19,11 +20,11 @@ export const tab: TabPassThroughOptions = {
 };
 export const tabPanel: TabPanelPassThroughOptions = {
   root: {
-    class: tw`min-h-96 py-24 outline-blue-800 focus-visible:outline-solid`,
+    class: tw`min-h-96 bg-[var(--p-tabs-tabpanel-background)] py-24 outline-blue-800 focus-visible:outline-solid`,
   },
 };
 export const tabList: TabListPassThroughOptions = {
   tabList: {
-    class: tw`relative flex before:absolute before:bottom-0 before:left-[50%] before:h-px before:w-[var(--tab-list-separator-width,100%)] before:-translate-x-1/2 before:bg-gray-600`,
+    class: tw`relative flex before:absolute before:bottom-0 before:left-[50%] before:h-px before:w-[var(--tab-list-separator-width,100%)] before:-translate-x-1/2 before:bg-[var(--p-tabs-tablist-border-color,var(--color-gray-600))]`,
   },
 };


### PR DESCRIPTION
This PR makes the appearance of tabs customizable, adding support for design tokens following the list in the [PrimeVue documentation](https://primevue.org/tabs/#theming.tokens).