### PR TITLE
fix(panelMenu): make label sizes more consistent

### DIFF
--- a/src/primevue/panelMenu/panelMenu.stories.ts
+++ b/src/primevue/panelMenu/panelMenu.stories.ts
@@ -43,7 +43,7 @@ export const Default: StoryObj<typeof meta> = {
       const expandedKeys = ref({ R: true, "R-A": true });
       return { args, items, expandedKeys };
     },
-    template: html`<label for="menu" class="ris-label2-regular mb-16 block"
+    template: html`<label for="menu" class="ris-label1-regular mb-16 block"
         >Dokumentarten</label
       ><PanelMenu
         id="menu"

--- a/src/primevue/panelMenu/panelMenu.ts
+++ b/src/primevue/panelMenu/panelMenu.ts
@@ -2,8 +2,8 @@ import { tw } from "@/lib/tags";
 import { PanelMenuPassThroughOptions } from "primevue/panelmenu";
 
 const pointer = tw`cursor-pointer`;
-const selected = tw`ris-label2-bold border-l-blue-800 bg-blue-200 text-black hover:bg-blue-300 focus-visible:bg-blue-300`;
-const notSelected = tw`hover:bg-blue-200 focus-visible:bg-blue-200`;
+const selected = tw`ris-label1-bold border-l-blue-800 bg-blue-200 text-black hover:bg-blue-300 focus-visible:bg-blue-300`;
+const notSelected = tw`ris-label1-regular hover:bg-blue-200 focus-visible:bg-blue-200`;
 
 const focusVisible = tw`focus-visible:outline-none`;
 const panelMenu: PanelMenuPassThroughOptions = {


### PR DESCRIPTION
This updates the panelMenu to consistently use `ris-label1-*`, whereas the selected and non-selected states differed previously (16px vs 18px).

Refers to RISDEV-7259.