### PR TITLE
feat(dataTable): add sticky header for scrollable dataTable

### DIFF
--- a/src/primevue/dataTable/dataTable.stories.ts
+++ b/src/primevue/dataTable/dataTable.stories.ts
@@ -187,3 +187,25 @@ export const Empty: Story = {
     `,
   }),
 };
+
+export const Scrollable: Story = {
+  args: {
+    value: sampleProducts,
+  },
+  render: (args) => ({
+    components: { DataTable, Column },
+    setup() {
+      return { args };
+    },
+    template: html`
+      <div class="card">
+        <DataTable v-bind="args" scrollable scroll-height="150px">
+          <Column field="code" header="Code"></Column>
+          <Column field="name" header="Name"></Column>
+          <Column field="category" header="Category"></Column>
+          <Column field="quantity" header="Quantity"></Column>
+        </DataTable>
+      </div>
+    `,
+  }),
+};

--- a/src/primevue/dataTable/dataTable.ts
+++ b/src/primevue/dataTable/dataTable.ts
@@ -18,9 +18,7 @@ const dataTable: DataTablePassThroughOptions = {
   },
 
   thead: {
-    style: {
-      borderBottom: "1px solid var(--color-blue-300)",
-    },
+    class: tw`sticky top-0 bg-white shadow-[0_1px_0_var(--color-blue-300)]`,
   },
 
   tbody: {


### PR DESCRIPTION
The border bottom was exchanged by a box shadow, because sticky headers using position: sticky inside scrollable containers (overflow: auto) can cause border-bottom on <thead> to disappear or be visually clipped during scroll due to browser rendering quirks (especially in Chromium-based browsers). These changes should make no difference for non-scrollable tables.