### PR TITLE
fix(chipsinput): focus input after adding new chip

### DIFF
--- a/src/components/RisChipsInput/RisChipsInput.unit.spec.ts
+++ b/src/components/RisChipsInput/RisChipsInput.unit.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/vue";
+import { render, screen } from "@testing-library/vue";
 import { describe, it, expect } from "vitest";
 import PrimeVue from "primevue/config";
 import RisChipsInput from "./RisChipsInput.vue";
@@ -126,24 +126,35 @@ describe("RisChipsInput", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("focus the rerendered new chip input after a chip has been added (with mask)", async () => {
+  it("focus the rerendered new chip input after a chip has been added", async () => {
+    const user = userEvent.setup();
+
     render(RisChipsInput, {
       props: {
         modelValue: [],
-        mask: "99.99.9999",
       },
       global: { plugins: [PrimeVue] },
     });
 
     const input = screen.getByRole("textbox", { name: "Eintrag hinzufügen" });
-    // Dispatching raw DOM events because user.type() throws an error in InputMask
-    await fireEvent.update(input, "01.01.1970");
-    await fireEvent.blur(input);
+    await user.type(input, "apple{enter}");
 
     const rerenderedInput = screen.getByRole("textbox", {
       name: "Eintrag hinzufügen",
     });
     expect(document.activeElement).toBe(rerenderedInput);
     expect(rerenderedInput).toHaveValue("");
+  });
+
+  it("group has aria invalid set to true when hasError prop is provided", async () => {
+    render(RisChipsInput, {
+      props: {
+        modelValue: [],
+        hasError: true,
+      },
+      global: { plugins: [PrimeVue] },
+    });
+
+    expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
   });
 });

--- a/src/components/RisChipsInput/RisChipsInput.vue
+++ b/src/components/RisChipsInput/RisChipsInput.vue
@@ -60,6 +60,7 @@ const conditionalClasses = computed(() => ({
     class="ris-body2-regular shadow-blue flex min-h-48 w-full cursor-text flex-row flex-wrap gap-8 bg-white px-16 py-8"
     :class="conditionalClasses"
     :aria-label="ariaLabel"
+    :aria-invalid="hasError"
     role="group"
     @click="focusNewChipInput"
   >


### PR DESCRIPTION
UX update: the create chip input should be focused after a new chip has been added. 
Also adds a fix (via a re-render TBD) to reset the create chip input. Interestingly for the `InputMask` the input still had the previous value although the model gets properly reset to `""`.