### PR TITLE
fix(datatable): add outline for focused rows

### DIFF
--- a/src/primevue/dataTable/dataTable.stories.ts
+++ b/src/primevue/dataTable/dataTable.stories.ts
@@ -113,7 +113,36 @@ export const Default: Story = {
   }),
 };
 
-export const Selectable: Story = {
+export const SingleSelectable: Story = {
+  args: {
+    value: sampleProducts,
+  },
+  render: (args) => ({
+    components: { DataTable, Column },
+    setup() {
+      const selectedProducts = ref([]);
+      return { args, selectedProducts };
+    },
+    template: html`
+      <div class="card">
+        <DataTable
+          class="p-32"
+          v-bind="args"
+          v-model:selection="selectedProducts"
+          dataKey="id"
+          selectionMode="single"
+        >
+          <Column field="code" header="Code"></Column>
+          <Column field="name" header="Name"></Column>
+          <Column field="category" header="Category"></Column>
+          <Column field="quantity" header="Quantity"></Column>
+        </DataTable>
+      </div>
+    `,
+  }),
+};
+
+export const MultiSelectable: Story = {
   args: {
     value: sampleProducts,
   },

--- a/src/primevue/dataTable/dataTable.stories.ts
+++ b/src/primevue/dataTable/dataTable.stories.ts
@@ -155,6 +155,35 @@ export const MultiSelectable: Story = {
     template: html`
       <div class="card">
         <DataTable
+          class="p-32"
+          v-bind="args"
+          v-model:selection="selectedProducts"
+          dataKey="id"
+          selectionMode="multiple"
+        >
+          <Column field="code" header="Code"></Column>
+          <Column field="name" header="Name"></Column>
+          <Column field="category" header="Category"></Column>
+          <Column field="quantity" header="Quantity"></Column>
+        </DataTable>
+      </div>
+    `,
+  }),
+};
+
+export const MultiSelectableCheckbox: Story = {
+  args: {
+    value: sampleProducts,
+  },
+  render: (args) => ({
+    components: { DataTable, Column },
+    setup() {
+      const selectedProducts = ref([]);
+      return { args, selectedProducts };
+    },
+    template: html`
+      <div class="card">
+        <DataTable
           v-bind="args"
           v-model:selection="selectedProducts"
           dataKey="id"

--- a/src/primevue/dataTable/dataTable.ts
+++ b/src/primevue/dataTable/dataTable.ts
@@ -25,14 +25,15 @@ const dataTable: DataTablePassThroughOptions = {
     class: tw`divide-y divide-blue-300`,
   },
 
-  bodyRow: {
-    class: tw`hover:bg-blue-100 focus:outline-4 focus:-outline-offset-5 focus:outline-blue-800 focus:not-focus-visible:outline-none focus-visible:outline-4 focus-visible:-outline-offset-5 focus-visible:outline-blue-800`,
-    // The selected row is registered correctly, but this styling is not attached correctly:
-    // https://github.com/primefaces/primevue/issues/7759
-    style: ({ context }: { context: DataTableContext }) => ({
-      backgroundColor: context.selected ? "var(--color-blue-300)" : undefined,
-    }),
-  },
+  bodyRow: ({ context }: { context: DataTableContext }) => ({
+    class: [
+      tw`focus:outline-4 focus:-outline-offset-5 focus:outline-blue-800 focus:not-focus-visible:outline-none focus-visible:outline-4 focus-visible:-outline-offset-5 focus-visible:outline-blue-800`,
+      {
+        "bg-blue-300": context.selected,
+        "hover:bg-blue-100": !context.selected,
+      },
+    ],
+  }),
 
   // height for td works like min-height: Table cells will grow when the content does not fit.
   column: {

--- a/src/primevue/dataTable/dataTable.ts
+++ b/src/primevue/dataTable/dataTable.ts
@@ -26,7 +26,7 @@ const dataTable: DataTablePassThroughOptions = {
   },
 
   bodyRow: {
-    class: tw`hover:bg-blue-100`,
+    class: tw`hover:bg-blue-100 focus:outline-4 focus:-outline-offset-5 focus:outline-blue-800 focus:not-focus-visible:outline-none focus-visible:outline-4 focus-visible:-outline-offset-5 focus-visible:outline-blue-800`,
     // The selected row is registered correctly, but this styling is not attached correctly:
     // https://github.com/primefaces/primevue/issues/7759
     style: ({ context }: { context: DataTableContext }) => ({

--- a/src/tailwind/global.css
+++ b/src/tailwind/global.css
@@ -141,14 +141,6 @@
     font-family: var(--font-sans);
     font-style: normal;
   }
-
-  /* 
-  This is the workaround for this issue in the dataTable: 
-  https://github.com/primefaces/primevue/issues/5105 
-  */
-  tr[data-p-selected="true"] {
-    background-color: var(--color-blue-300);
-  }
 }
 
 /* Utilities */


### PR DESCRIPTION
* add RIS-UI style for focused table rows
* inset outline so its not cutoff on the sides
* inset outline so its not hidden behind the table header's divider

HINT: Focus the table once using the tab key or by clicking on a  row. Navigate rows using the arrow up/down keys -> this shows the focus outline.