### PR TITLE
feat(tooltip): add tooltip directive

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,7 @@ import "../public/fonts.css";
 import { deDE } from "../src/config/locale";
 import { RisUiTheme } from "../src/primevue";
 import "./preview.css";
+import Tooltip from "primevue/tooltip";
 
 initialize({
   serviceWorker: {
@@ -29,6 +30,8 @@ setup((app) => {
   app.use(ConfirmationService);
 
   app.use(ToastService);
+
+  app.directive("tooltip", Tooltip);
 });
 
 const preview: Preview = {

--- a/src/primevue/index.ts
+++ b/src/primevue/index.ts
@@ -22,6 +22,7 @@ import tree from "./tree/tree";
 import splitter from "./splitter/splitter";
 import dataTable from "./dataTable/dataTable";
 import { tab, tabPanel, tabList } from "./tabs/tabs";
+import tooltip from "./tooltip/tooltip";
 
 import { deDE } from "@/config/locale";
 
@@ -52,6 +53,9 @@ export const RisUiTheme = {
   tab,
   tabPanel,
   tabList,
+  directives: {
+    tooltip,
+  },
 };
 
 export const RisUiLocale = {

--- a/src/primevue/tooltip/tooltip.stories.ts
+++ b/src/primevue/tooltip/tooltip.stories.ts
@@ -1,0 +1,49 @@
+import { html } from "@/lib/tags.ts";
+import { Meta, StoryObj } from "@storybook/vue3-vite";
+import Tooltip from "primevue/tooltip";
+import InputText from "primevue/inputtext";
+
+const meta: Meta<typeof Tooltip> = {
+  // @ts-expect-error Component type broken
+  component: Tooltip,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => ({
+    components: { InputText },
+    setup() {},
+    template: html`
+      <div class="card flex flex-wrap justify-items-start gap-16">
+        <InputText
+          v-tooltip="'Look at these fields'"
+          type="text"
+          placeholder="Default"
+        />
+        <InputText
+          v-tooltip.right="'and input some data'"
+          type="text"
+          placeholder="Right"
+        />
+        <InputText
+          v-tooltip.top="'whatever you feel like,'"
+          type="text"
+          placeholder="Top"
+        />
+        <InputText
+          v-tooltip.bottom="'validate if you wish,'"
+          type="text"
+          placeholder="Bottom"
+        />
+        <InputText
+          v-tooltip.left="'and donʼt forget aria-labels.'"
+          type="text"
+          placeholder="Left"
+        />
+      </div>
+    `,
+  }),
+};

--- a/src/primevue/tooltip/tooltip.ts
+++ b/src/primevue/tooltip/tooltip.ts
@@ -1,0 +1,31 @@
+import { TooltipDirectivePassThroughOptions } from "primevue/tooltip";
+import { tw } from "@/lib/tags.ts";
+
+const tooltip: TooltipDirectivePassThroughOptions = {
+  arrow: ({ context }) => {
+    const base = tw`absolute h-0 w-0 border-[7px] border-solid`;
+    const top = tw`-mr-[7px] border-b-0 border-t-gray-900 border-r-transparent border-l-transparent`;
+    const right = tw`-mt-[7px] border-l-0 border-t-transparent border-r-gray-900 border-b-transparent`;
+    const bottom = tw`-ml-[7px] border-t-0 border-r-transparent border-b-gray-900 border-l-transparent`;
+    const left = tw`-mt-[7px] border-r-0 border-t-transparent border-b-transparent border-l-gray-900`;
+
+    const noPlacementDefined =
+      !context.top && !context.right && !context.bottom && !context.left;
+
+    return {
+      class: {
+        [base]: true,
+        [top]: context.top,
+        [right]: context.right || noPlacementDefined,
+        [bottom]: context.bottom,
+        [left]: context.left,
+      },
+    };
+  },
+  text: { class: tw`m-[7px] rounded-sm bg-gray-900 px-8 py-4 text-white` },
+  root: {
+    class: tw`absolute`,
+  },
+};
+
+export default tooltip;

--- a/src/primevue/tooltip/tooltip.ts
+++ b/src/primevue/tooltip/tooltip.ts
@@ -3,6 +3,8 @@ import { tw } from "@/lib/tags.ts";
 
 const tooltip: TooltipDirectivePassThroughOptions = {
   arrow: ({ context }) => {
+    // build a triangle by defining a zero-pixel element with two transparent
+    // borders on the sides and one solid border in the middle
     const base = tw`absolute h-0 w-0 border-[7px] border-solid`;
     const top = tw`-mr-[7px] border-b-0 border-t-gray-900 border-r-transparent border-l-transparent`;
     const right = tw`-mt-[7px] border-l-0 border-t-transparent border-r-gray-900 border-b-transparent`;
@@ -22,7 +24,9 @@ const tooltip: TooltipDirectivePassThroughOptions = {
       },
     };
   },
-  text: { class: tw`m-[7px] rounded-sm bg-gray-900 px-8 py-4 text-white` },
+  text: {
+    class: tw`ris-label3-regular m-[7px] rounded-sm bg-gray-900 px-8 py-4 text-center whitespace-pre-line text-white`,
+  },
   root: {
     class: tw`absolute`,
   },


### PR DESCRIPTION
This PR adds support for the PrimeVue tooltip.

The tooltip arrow triangle is achieved by defining a zero-pixel element with two transparent borders on the sides and one solid border in the middle.

<img width="394" alt="image" src="https://github.com/user-attachments/assets/fa63d586-c70c-4688-abd3-29b74e2fb0f8" />
